### PR TITLE
Expose lavasearch under the api scope

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -14,7 +14,7 @@ java {
 }
 
 dependencies {
-    implementation "com.github.topi314.lavasearch:lavasearch:1.0.0-beta.2"
+    api "com.github.topi314.lavasearch:lavasearch:1.0.0-beta.2"
     compileOnly "dev.arbjerg:lavaplayer:2.0.1"
     implementation "org.jsoup:jsoup:1.15.3"
     implementation "commons-io:commons-io:2.7"


### PR DESCRIPTION
I am encountering this compiler error with LavaSrc as a dependency:

```
e: Supertypes of the following classes cannot be resolved. Please make sure you have the required dependencies in the classpath:
    class com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager, unresolved supertypes: com.github.topi314.lavasearch.AudioSearchSourceManager
Adding -Xextended-compiler-checks argument might provide additional information.

e: file:///home/freya/git/tenshi/tenshi/src/main/java/fredboat/config/AudioPlayerManagerConfiguration.kt:296:74 Cannot access 'com.github.topi314.lavasearch.AudioSearchSourceManager' which is a supertype of 'com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager'. Check your module classpath for missing or conflicting dependencies
```

The problem appears to be that `AudioSearchSourceManager` is unavailable as a transitive dependency because of the `implementation` scope. I have not tested this PR, however putting lavasearch into scope in my project fixes the compile error.