### PR TITLE
Enhancements in Track Handling and Artist Recognition for Yandex Music

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/applemusic/AppleMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/applemusic/AppleMusicSourceManager.java
@@ -403,7 +403,7 @@ public class AppleMusicSourceManager extends MirroringAudioSourceManager impleme
 		var artistId = this.parseArtistId(json);
 		String artistArtwork = null;
 		if (artistId != null) {
-			artistArtwork = getArtistCover(List.of()).values().iterator().next();
+			artistArtwork = getArtistCover(List.of(artistId)).values().iterator().next();
 		}
 		return parseTrack(json.get("data").index(0), preview, artistArtwork);
 	}

--- a/main/src/main/java/com/github/topi314/lavasrc/applemusic/AppleMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/applemusic/AppleMusicSourceManager.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 
 public class AppleMusicSourceManager extends MirroringAudioSourceManager implements AudioSearchManager {
 
-	public static final Pattern URL_PATTERN = Pattern.compile("(https?://)?(www\\.)?music\\.apple\\.com/((?<countrycode>[a-zA-Z]{2})/)?(?<type>album|playlist|artist|song)(/[a-zA-Z\\d\\-]+)?/(?<identifier>[a-zA-Z\\d\\-.]+)(\\?i=(?<identifier2>\\d+))?");
+	public static final Pattern URL_PATTERN = Pattern.compile("(https?://)?(www\\.)?music\\.apple\\.com/((?<countrycode>[a-zA-Z]{2})/)?(?<type>album|playlist|artist|song)(/[a-zA-Z\\p{L}\\d\\-]+)?/(?<identifier>[a-zA-Z\\d\\-.]+)(\\?i=(?<identifier2>\\d+))?");
 	public static final String SEARCH_PREFIX = "amsearch:";
 	public static final String PREVIEW_PREFIX = "amprev:";
 	public static final long PREVIEW_LENGTH = 30000;

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -10,20 +10,15 @@ import com.sedmelluq.discord.lavaplayer.tools.io.HttpConfigurable;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
 import com.sedmelluq.discord.lavaplayer.track.*;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -79,8 +74,8 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 						var artistId = matcher.group("identifier");
 						return this.getArtist(artistId);
 					case "track":
-					    	var trackId = matcher.group("identifier");
-					    	return this.getTrack(trackId);
+						var trackId = matcher.group("identifier");
+						return this.getTrack(trackId);
 				}
 				return null;
 			}
@@ -155,7 +150,7 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 		return new YandexMusicAudioPlaylist(author + "'s Top Tracks", tracks, ExtendedAudioPlaylist.Type.ARTIST, json.get("result").get("url").text(), this.formatCoverUri(coverUri), author);
 	}
 
-	private AudioItem getPlaylist(String userString, String id) throws IOException, URISyntaxException {
+	private AudioItem getPlaylist(String userString, String id) throws IOException {
 		var json = this.getJson(PUBLIC_API_BASE + "/users/" + userString + "/playlists/" + id);
 		if (json.isNull() || json.get("result").isNull() || json.get("result").get("tracks").values().isEmpty()) {
 			return AudioReference.NO_TRACK;
@@ -186,8 +181,8 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 
 	private String getTrackIds(List<JsonBrowser> tracksToParse) {
 		return tracksToParse.stream()
-				.map(node -> node.get("id").text())
-				.collect(Collectors.joining(","));
+			.map(node -> node.get("id").text())
+			.collect(Collectors.joining(","));
 	}
 
 	public JsonBrowser getJson(String uri) throws IOException {
@@ -255,8 +250,8 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 
 	private String extractArtists(JsonBrowser artistNode) {
 		return artistNode.values().stream()
-				.map(node -> node.get("name").text())
-				.collect(Collectors.joining(", "));
+			.map(node -> node.get("name").text())
+			.collect(Collectors.joining(", "));
 	}
 
 	private String formatCoverUri(String coverUri) {

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -191,10 +191,6 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 	}
 
 	public JsonBrowser getJson(String uri) throws IOException {
-		return getJson(URI.create(uri));
-	}
-
-	public JsonBrowser getJson(URI uri) throws IOException {
 		var request = new HttpGet(uri);
 		request.setHeader("Accept", "application/json");
 		request.setHeader("Authorization", "OAuth " + this.accessToken);

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -214,7 +214,7 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 				id,
 				false,
 				"https://music.yandex.ru/track/" + id,
-					this.formatCoverUri(coverUri),
+				this.formatCoverUri(coverUri),
 				null
 			),
 			this

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -90,7 +90,7 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 				var playlistId = matcher.group("identifier2");
 				return this.getPlaylist(userId, playlistId);
 			}
-		} catch (IOException | URISyntaxException e) {
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 		return null;

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -194,10 +194,6 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 		return getJson(URI.create(uri));
 	}
 
-	public JsonBrowser getJson(String uri, List<NameValuePair> params) throws URISyntaxException, IOException {
-		return getJson(buildUriWithParams(uri, params));
-	}
-
 	public JsonBrowser getJson(URI uri) throws IOException {
 		var request = new HttpGet(uri);
 		request.setHeader("Accept", "application/json");

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -180,10 +180,8 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 		return new YandexMusicAudioPlaylist(playlistTitle, tracks, ExtendedAudioPlaylist.Type.PLAYLIST, json.get("result").get("url").text(), this.formatCoverUri(coverUri), author);
 	}
 
-	private List<JsonBrowser> getTracks(String trackIds) throws URISyntaxException, IOException {
-		return getJson(PUBLIC_API_BASE + "/tracks", new ArrayList<>() {{
-			add(new BasicNameValuePair("track-ids", trackIds));
-		}}).get("result").values();
+	private List<JsonBrowser> getTracks(String trackIds) throws IOException {
+		return getJson(PUBLIC_API_BASE + "/tracks?track-ids=" + URLEncoder.encode(trackIds, StandardCharsets.UTF_8)).get("result").values();
 	}
 
 	private String getTrackIds(List<JsonBrowser> tracksToParse) {

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -93,7 +93,7 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 		} catch (IOException | URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
-        return null;
+		return null;
 	}
 
 	private AudioItem getSearch(String query) throws IOException {

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -29,8 +29,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigurable {
-	public static final Pattern URL_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(ru|com)/(?<type1>artist|album)/(?<identifier>[0-9]+)/?((?<type2>track/)(?<identifier2>[0-9]+)/?)?");
-	public static final Pattern URL_TRACK_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(ru|com)/(?<type1>track)/(?<identifier>[0-9]+)");
+	public static final Pattern URL_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(ru|com)/(?<type1>artist|album|track)/(?<identifier>[0-9]+)(/(?<type2>track)/(?<identifier2>[0-9]+))?/?");
 	public static final Pattern URL_PLAYLIST_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(ru|com)/users/(?<identifier>[0-9A-Za-z@.-]+)/playlists/(?<identifier2>[0-9]+)/?");
 	public static final String SEARCH_PREFIX = "ymsearch:";
 	public static final String PUBLIC_API_BASE = "https://api.music.yandex.net";
@@ -74,13 +73,11 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 					case "artist":
 						var artistId = matcher.group("identifier");
 						return this.getArtist(artistId);
+					case "track":
+					    	var trackId = matcher.group("identifier");
+					    	return this.getTrack(trackId);
 				}
 				return null;
-			}
-			matcher = URL_TRACK_PATTERN.matcher(reference.identifier);
-			if (matcher.find()) {
-				var trackId = matcher.group("identifier");
-				return this.getTrack(trackId);
 			}
 			matcher = URL_PLAYLIST_PATTERN.matcher(reference.identifier);
 			if (matcher.find()) {

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -205,10 +205,6 @@ public class YandexMusicSourceManager implements AudioSourceManager, HttpConfigu
 		return LavaSrcTools.fetchResponseAsJson(this.httpInterfaceManager.getInterface(), request);
 	}
 
-	private URI buildUriWithParams(String uri, List<NameValuePair> params) throws URISyntaxException {
-		return new URIBuilder(uri).addParameters(params).build();
-	}
-
 	public String getDownloadStrings(String uri) throws IOException {
 		var request = new HttpGet(uri);
 		request.setHeader("Accept", "application/json");


### PR DESCRIPTION
Added support for manually uploaded tracks (only those uploaded by the token owner available)

Implemented recognition of track links without specifying the album, e.g., https://music.yandex.ru/track/75370207

Now, if a track has multiple artists, all of them will be listed in the author field instead of just one.