### PR TITLE
Add Yandex Music Radio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,54 @@ LavaSrc adds the following fields to tracks & playlists in Lavalink
 * https://music.yandex.ru/users/yamusic-bestsongs/playlists/701626
 * https://music.yandex.ru/artist/701626
 
+### Yandex Music Radio a.k.a "My Vibe"
+* `ymradio:<type>:<tag>`
+
+An infinite stream of tracks, generated based on certain criteria. Whether you're looking for tracks similar to a specific playlist, songs resonating with a particular artist's style, or the "My Vibe" feature that curates songs tailored just for you, this radio has got it all!
+
+**Type** - The type of radio. It can be one of the following:
+- `user`
+- `artist`
+- `album`
+- `playlist`
+- `track`
+- `genre`
+
+**Tag** - The radio identifier.
+
+**Examples**:
+- `user:onyourwave` (My Vibe)
+- `track:{trackId}` (Radio by Track)
+- `playlist:{playlistOwnerId_playlistId}` (Radio by Playlist)
+- `album:{albumId}` (Radio by Album)
+- `artist:{artistId}` (Radio by Artist)
+- `genre:(pop|rap|rock|etc)` (Radio by Genre)
+
+**Sample Implementation**:
+```java
+// Inside AudioLoadResultHandler
+@Override
+public void trackLoaded(AudioTrack track) {
+    if (track instanceof YandexMusicAudioRadio) {
+        YandexMusicAudioRadio radio = (YandexMusicAudioRadio) track:
+        //save instance for that radio somewhere in your player that extends @AudioEventAdapter
+        audioPlayer.startTrack(radio.nextTrack());
+    }
+}
+
+// Inside AudioEventAdapter
+@Override
+public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
+    if (endReason.mayStartNext) {
+        try {
+            player.startTrack(radio.nextTrack(), false);
+        } catch (URISyntaxException | IOException e) {
+            e.printStackTrace();
+        }
+    }
+}
+```
+
 ### Flowery TTS
 You can ready about all the available options [here](https://flowery.pw/docs/flowery/synthesize-v-1-tts-get),
 a list of available voices is [here](https://api.flowery.pw/v1/tts/voices)

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/radio/AudioRadioBatch.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/radio/AudioRadioBatch.java
@@ -1,0 +1,24 @@
+package com.github.topi314.lavasrc.yandexmusic.radio;
+
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+
+import java.util.List;
+
+public class AudioRadioBatch {
+
+    private final String batchId;
+    private final List<AudioTrack> audioTracks;
+
+    public AudioRadioBatch(String batchId, List<AudioTrack> audioTracks) {
+        this.batchId = batchId;
+        this.audioTracks = audioTracks;
+    }
+
+    public String getBatchId() {
+        return batchId;
+    }
+
+    public List<AudioTrack> getAudioTracks() {
+        return audioTracks;
+    }
+}

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/radio/YandexMusicAudioRadio.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/radio/YandexMusicAudioRadio.java
@@ -1,0 +1,186 @@
+package com.github.topi314.lavasrc.yandexmusic.radio;
+
+import com.github.topi314.lavasrc.yandexmusic.YandexMusicSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.track.*;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Objects;
+
+public class YandexMusicAudioRadio implements AudioItem, AudioTrack {
+
+    private final String name;
+    private final String station;
+    private final String batchId;
+    private List<AudioTrack> stationTracks;
+    private final YandexMusicSourceManager sourceManager;
+    private AudioTrack currentTrack;
+    private int index = 0;
+    private static final String HREF = "https://music.yandex.ru/";
+
+    public YandexMusicAudioRadio(String name, String station, String batchId, List<AudioTrack> stationTracks, YandexMusicSourceManager sourceManager) {
+        this.name = name;
+        this.station = station;
+        this.batchId = batchId;
+        this.stationTracks = stationTracks;
+        this.sourceManager = sourceManager;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getUrl() {
+        var type = station.split(":")[0];
+        var tag = station.split(":")[1].split("_");
+        switch (type) {
+            case "playlist":
+                return HREF + "users/" + tag[0] + "/playlists/" + tag[1];
+            case "album":
+                return HREF + "album/" + tag[0];
+            case "track":
+                return HREF + "track/" + tag[0];
+            case "artist":
+                return HREF + "artist/" + tag[0];
+            default:
+                return null;
+        }
+    }
+
+    public String getStation() {
+        return this.station;
+    }
+
+    public String getBatchId() {
+        return this.batchId;
+    }
+
+    public AudioTrack nextTrack() throws URISyntaxException, IOException {
+        if (Objects.isNull(currentTrack)) {
+            this.sendStartRadio();
+        }
+        else {
+            this.sendPlayEndRadio();
+            this.index += 1;
+            if (this.index >= stationTracks.size()) {
+                this.updateRadioBatch();
+            }
+        }
+        currentTrack = this.updateCurrentTrack();
+        return currentTrack;
+    }
+
+    public AudioTrack skipTrack() throws URISyntaxException, IOException {
+        if (Objects.isNull(currentTrack)) {
+            this.sendStartRadio();
+            this.updateCurrentTrack();
+        } else {
+            this.sendPlaySkipRadio();
+            this.index += 1;
+            if (this.index >= stationTracks.size()) {
+                this.updateRadioBatch();
+            }
+            this.updateCurrentTrack();
+        }
+        return currentTrack;
+    }
+
+    public AudioTrack getCurrent() {
+        return currentTrack;
+    }
+
+    public List<AudioTrack> getStationTracks() {
+        return stationTracks;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    private void updateRadioBatch() throws IOException, URISyntaxException {
+        this.index = 0;
+        AudioRadioBatch radioBatch = this.sourceManager.getRadioBatch(this.station, currentTrack != null ? currentTrack.getIdentifier() : null);
+        this.stationTracks = radioBatch.getAudioTracks();
+        this.sendStartRadio();
+    }
+
+    private AudioTrack updateCurrentTrack() throws URISyntaxException, IOException {
+        currentTrack = stationTracks.get(index);
+        this.sendPlayStartRadio();
+        return currentTrack;
+    }
+
+    private void sendStartRadio() throws IOException, URISyntaxException {
+        sourceManager.radioFeedBackRadioStarted(station, batchId);
+    }
+
+    private void sendPlayEndRadio() throws URISyntaxException, IOException {
+        sourceManager.radioFeedBackTrackFinished(station, currentTrack, currentTrack.getPosition() / 1000, batchId);
+    }
+
+    private void sendPlayStartRadio() throws URISyntaxException, IOException {
+        sourceManager.radioFeedBackTrackStarted(station, currentTrack, batchId);
+    }
+
+    private void sendPlaySkipRadio() throws URISyntaxException, IOException {
+        sourceManager.radioFeedBackTrackSkipped(station, currentTrack, currentTrack.getPosition() / 1000, batchId);
+    }
+
+    public AudioTrackInfo getInfo() {
+        return currentTrack.getInfo();
+    }
+
+    public String getIdentifier() {
+        return currentTrack.getIdentifier();
+    }
+
+    public AudioTrackState getState() {
+        return currentTrack.getState();
+    }
+
+    public void stop() {
+        currentTrack.stop();
+    }
+
+    public boolean isSeekable() {
+        return false;
+    }
+
+    public long getPosition() {
+        return currentTrack.getPosition();
+    }
+
+    public void setPosition(long position) {
+        currentTrack.setPosition(position);
+    }
+
+    public void setMarker(TrackMarker marker) {
+        currentTrack.setMarker(marker);
+    }
+
+    public long getDuration() {
+        return currentTrack.getDuration();
+    }
+
+    public AudioTrack makeClone() {
+        return currentTrack.makeClone();
+    }
+
+    public AudioSourceManager getSourceManager() {
+        return currentTrack.getSourceManager();
+    }
+
+    public void setUserData(Object userData) {
+        currentTrack.setUserData(userData);
+    }
+
+    public Object getUserData() {
+        return currentTrack.getUserData();
+    }
+
+    public <T> T getUserData(Class<T> klass) {
+        return currentTrack.getUserData(klass);
+    }
+}


### PR DESCRIPTION
In Yandex Music, there is an option to launch a stream of songs based on a playlist, track, album, artist, or genre. This feature is called "radio" or "My Vibe". This functionality allows developers to use this feature in their bots. The track retrieval cycle is not fully understood, and there are often repeated tracks, but otherwise, it works as it should. This feature is expandable; some "streams" can be customized, specifically to select the mood, language, and a few others. I will try to implement this functionality in the future if possible.

Perhaps in the future, if there is an implementation of a similar radio in other services, it's worth adding radio as a separate item, in addition to the track and playlist. However, for now, it's just a reiteration of AudioTrack.