### PR TITLE
Fix README.md incorrect imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ repositories {
 
 dependencies {
   implementation "com.github.topi314.lavasrc:lavasrc:x.y.z"
-  implementation "com.github.topi314.lavasrc:lavasrc-protocol:x.y.z"
+  implementation "com.github.topi314.lavasrc:lavasrc-plugin:x.y.z"
 }
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ repositories {
 
 dependencies {
   implementation "com.github.topi314.lavasrc:lavasrc:x.y.z"
-  implementation "com.github.topi314.lavasrc:lavasrc-plugin:x.y.z"
+  implementation "com.github.topi314.lavasrc:lavasrc-protocol:x.y.z"
 }
 ```
 </details>
@@ -69,7 +69,7 @@ dependencies {
   </dependency>
   <dependency>
       <groupId>com.github.topi314.lavasrc</groupId>
-      <artifactId>lavasrc-plugin</artifactId>
+      <artifactId>lavasrc-protocol</artifactId>
       <version>x.y.z</version>
   </dependency>
 </dependencies>

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ dependencies {
 ```xml
 <repositories>
   <repository>
+    <id>TopiWTF-releases</id>
+    <name>Topis Maven Repo</name>
     <url>https://maven.topi.wtf/releases</url>
   </repository>
 </repositories>
@@ -67,7 +69,7 @@ dependencies {
   </dependency>
   <dependency>
       <groupId>com.github.topi314.lavasrc</groupId>
-      <artifactId>lavasrc-protocol</artifactId>
+      <artifactId>lavasrc-plugin</artifactId>
       <version>x.y.z</version>
   </dependency>
 </dependencies>


### PR DESCRIPTION
The maven and gradle imports had lavasrc-protocol instead of lavasrc-plugin, as well as maven didn't have a id for repository. 