### PR TITLE
Fix not parsing full Deezer playlists

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
@@ -308,9 +308,16 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 		var artworkUrl = json.get("picture_xl").text();
 		var author = json.get("creator").get("name").text();
 
-		var tracks = this.getJson(PUBLIC_API_BASE + "/playlist/" + id + "/tracks");
+		// This endpoint returns tracks with ISRC, unlike the other REST call
+		var tracks = this.getJson(PUBLIC_API_BASE + "/playlist/" + id + "/tracks?limit=10000");
 
-		return new DeezerAudioPlaylist(json.get("title").text(), this.parseTracks(tracks, preview), DeezerAudioPlaylist.Type.PLAYLIST, json.get("link").text(), artworkUrl, author, (int) json.get("nb_tracks").asLong(0));
+		return new DeezerAudioPlaylist(json.get("title").text(),
+				this.parseTracks(tracks, preview),
+				DeezerAudioPlaylist.Type.PLAYLIST,
+				json.get("link").text(),
+				artworkUrl,
+				author,
+				(int) json.get("nb_tracks").asLong(0));
 	}
 
 	private AudioItem getArtist(String id, boolean preview) throws IOException {


### PR DESCRIPTION
This allows lavasrc to process more than the first 25 tracks in a Deezer playlist.

This removes the API call to Deezer at `/playlist/:id/tracks` and uses the already fetched data from `/playlist/:id` instead. It appears that the former is paginated, returning 25 results, whereas the latter returns the full dataset without pagination.

Here is a playlist you can use for testing: https://www.deezer.com/en/playlist/11958416461?host=5617782001&deferredFl=1

The above playlist yielded 243/260 tracks in my testing with this patch.