### PR TITLE
added support for fetching recommendations from deezer

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ searchManager.registerSearchManager(vkmusic);
 
 * `dzsearch:animals architects`
 * `dzisrc:USEP42058010`
+* `dzrec:1090538082` (`dzrec:{TRACK_ID}`)
 * https://deezer.page.link/U6BTQ2Q1KpmNt2yh8
 * https://www.deezer.com/track/1090538082
 * https://www.deezer.com/album/175537082


### PR DESCRIPTION
```py
async def fetch_deezer_recos(
    session_id: str, api_token: str, track_id: int
) -> Dict[str, Any]:
    url = f"https://www.deezer.com/ajax/gw-light.php?method=song.getSearchTrackMix&input=3&api_version=1.0&api_token={api_token}"
    data = {"sng_id": track_id, "start_with_input_track": "true"}
    headers = {"Cookie": f"sid={session_id}"}
    request = httpx.Request(method="POST", url=url, json=data, headers=headers)
    return await fetch_as_json(request)
```
Now, Deezer has a recommendations API that allows fetching recommendations without user authentication using the track ID. This is particularly helpful since Spotify stopped providing recommendations due to recent API changes, making Deezer a viable replacement for Spotify in this regard.
    
    