### PR TITLE
Fix "Invalid CSRF token" err for the Deezer recommendations

### DIFF
--- a/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/deezer/DeezerAudioSourceManager.java
@@ -414,7 +414,7 @@ public class DeezerAudioSourceManager extends ExtendedAudioSourceManager impleme
 		}
 
 		var request = new HttpPost(DeezerAudioSourceManager.PRIVATE_API_BASE + String.format("?method=%s&input=3&api_version=1.0&api_token=%s", method, tokens.api));
-		request.setHeader("Cookie", "sid=" + tokens.sessionId);
+		request.setHeader("Cookie", "sid=" + tokens.sessionId + "; dzr_uniq_id=" + tokens.dzrUniqId);
 		request.setHeader("Content-Type", "application/json");
 		request.setEntity(new StringEntity(payload, StandardCharsets.UTF_8));
 


### PR DESCRIPTION
Hi, I’m no an expert, not on GitHub this is my first PR. 
I noticed this error when trying to get Deezer recommendations using dzrec in LavaPlayer:

`Failed to get recommendations: {"VALID_TOKEN_REQUIRED":"Invalid CSRF token"}`

I fixed it by adding dzr_uniq_id to the Cookie header along with sid.

Please review :)