### PR TITLE
Add support for new Yandex Music playlist URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,7 @@ playerManager.registerSourceManager(new YTDLPSourceManager("path/to/yt-dlp"));
 * https://music.yandex.ru/album/13886032
 * https://music.yandex.ru/track/71663565
 * https://music.yandex.ru/users/yamusic-bestsongs/playlists/701626
+* https://music.yandex.ru/playlists/e1bb61b5-360d-e3c5-124c-ef58d981ca7d
 * https://music.yandex.ru/artist/701626
 
 ### Flowery TTS

--- a/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
+++ b/main/src/main/java/com/github/topi314/lavasrc/yandexmusic/YandexMusicSourceManager.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class YandexMusicSourceManager extends ExtendedAudioSourceManager implements HttpConfigurable, AudioLyricsManager, AudioSearchManager {
 	public static final Pattern URL_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(?<domain>ru|com|kz|by)/(?<type1>artist|album|track)/(?<identifier>[0-9]+)(/(?<type2>track)/(?<identifier2>[0-9]+))?/?");
 	public static final Pattern URL_PLAYLIST_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(?<domain>ru|com|kz|by)/users/(?<identifier>[0-9A-Za-z@.-]+)/playlists/(?<identifier2>[0-9]+)/?");
-	public static final Pattern URL_PLAYLIST_UUID_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(?<domain>ru|com|kz|by)/playlists/(?<identifier>([a-z]{2}\\.)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})");
+	public static final Pattern URL_PLAYLIST_UUID_PATTERN = Pattern.compile("(https?://)?music\\.yandex\\.(?<domain>ru|com|kz|by)/playlists/(?<identifier>[0-9A-Za-z\\-.]+)");
 	public static final Pattern EXTRACT_LYRICS_STROKE = Pattern.compile("\\[(?<min>\\d{2}):(?<sec>\\d{2})\\.(?<mil>\\d{2})] ?(?<text>.+)?");
 	public static final String SEARCH_PREFIX = "ymsearch:";
 	public static final String RECOMMENDATIONS_PREFIX = "ymrec:";


### PR DESCRIPTION
Adds support for new URLs type containing UUIDs.

Tested with:
- https://music.yandex.ru/playlists/e1bb61b5-360d-e3c5-124c-ef58d981ca7d
- https://music.yandex.ru/playlists/lk.a4423efa-296b-4f9d-9e24-61907a8ae2f1
- https://music.yandex.ru/playlists/lk.4ce94cae-0fe0-43f3-8996-1ec504adbf98?utm_source=web&utm_medium=copy_link
- https://music.yandex.ru/playlists/ps.1105710d-6405-47ff-b011-c7242318ba53?utm_source=web&utm_medium=copy_link

Old URL format still works as expected.